### PR TITLE
added template for /etc/apache2/ports.conf if default port is changed

### DIFF
--- a/tasks/config_apache2.yml
+++ b/tasks/config_apache2.yml
@@ -58,3 +58,14 @@
   notify:
     - restart httpd
   when: ansible_os_family == "RedHat"
+
+- name: config_apache2 | Configuring Apache2 Website(s)
+  template:
+    src: etc/apache2/ports.conf.j2
+    dest: /etc/apache2/ports.conf
+  become: true
+  notify:
+    - restart apache2
+  when: >
+        ansible_os_family == "Debian" and
+        apache2_default_port != "80"

--- a/templates/etc/apache2/ports.conf.j2
+++ b/templates/etc/apache2/ports.conf.j2
@@ -1,0 +1,15 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen {{ apache2_default_port }}
+
+<IfModule ssl_module>
+	Listen 443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen 443
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Before /etc/apache2/ports.conf was not changed and in turn the listening port remained on 80